### PR TITLE
feat: 投稿一覧画面にページネーションを実装した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,12 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# ページネーション [https://github.com/ddnexus/pagy]
+gem 'pagy'
+
+# 国際化
+gem 'rails-i18n'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
     nio4r (2.7.1)
     nokogiri (1.16.3-aarch64-linux)
       racc (~> 1.4)
+    pagy (8.4.3)
     parallel (1.24.0)
     parser (3.3.1.0)
       ast (~> 2.4.1)
@@ -206,6 +207,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.1.3.2)
       actionpack (= 7.1.3.2)
       activesupport (= 7.1.3.2)
@@ -329,10 +333,12 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   mysql2
+  pagy
   pry-byebug
   pry-rails
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
+  rails-i18n
   ridgepole
   rspec-rails
   rubocop

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,9 @@ class ApplicationController < ActionController::Base
   # sessions_helperのメソッドをMIXINする
   include SessionsHelper
 
+  # pagy gem
+  include Pagy::Backend
+
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
 
   # GET /posts
   def index
-    @posts = Post.all
+    @pagy, @posts = pagy(Post.all, item: 10)
   end
 
   # GET /posts/:id

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
 
   # GET /posts
   def index
-    @pagy, @posts = pagy(Post.all, item: 10)
+    @pagy, @posts = pagy(Post.all, items: 10)
   end
 
   # GET /posts/:id

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  # pagy gem
+  include Pagy::Frontend
+
+  # ページタイトル
   BASE_TITLE = 'だべったー'.freeze
   def full_title(page_title)
     if page_title.blank?

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -20,3 +20,6 @@
     </table>
   <% end %>
 </div>
+
+<%== pagy_nav(@pagy) %>
+<%== pagy_info(@pagy) %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,9 @@ module App
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}").to_s]
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,9 +11,10 @@
 User.create(email: 'user1@example.com', password: 'p@ssw0rd', password_confirmation: 'p@ssw0rd')
 User.create(email: 'user2@example.com', password: 'hogehoge', password_confirmation: 'hogehoge')
 
-Post.create(user_id: 1, title: 'タイトル1-1', content: '本文1-1')
-Post.create(user_id: 1, title: 'タイトル1-2', content: '本文1-2')
-Post.create(user_id: 1, title: 'タイトル1-3', content: '本文1-3')
-Post.create(user_id: 2, title: 'タイトル2-1', content: '本文2-1')
-Post.create(user_id: 2, title: 'タイトル2-2', content: '本文2-2')
-Post.create(user_id: 2, title: 'タイトル2-3', content: '本文2-3')
+30.times do
+  user_id = rand(1..2)
+  title = Faker::Lorem.sentence
+  content = Faker::Lorem.paragraph
+
+  Post.create(user_id:, title:, content:)
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Post, type: :model do
         aggregate_failures do
           expect(post.valid?).to be false
           expect(post.errors.details[:title]).to include(a_hash_including(error: :too_long))
-          expect(post.errors.full_messages_for(:title)).to eq(['Title is too long (maximum is 30 characters)'])
+          expect(post.errors.full_messages_for(:title)).to eq(['Titleは30文字以内で入力してください'])
         end
       end
     end
@@ -43,7 +43,7 @@ RSpec.describe Post, type: :model do
         aggregate_failures do
           expect(post.valid?).to be false
           expect(post.errors.details[:content]).to include(error: :blank)
-          expect(post.errors.full_messages_for(:content)).to eq(["Content can't be blank"])
+          expect(post.errors.full_messages_for(:content)).to eq(['Contentを入力してください'])
         end
       end
     end
@@ -55,7 +55,7 @@ RSpec.describe Post, type: :model do
         aggregate_failures do
           expect(post.valid?).to be false
           expect(post.errors.details[:content]).to include(a_hash_including(error: :too_long))
-          expect(post.errors.full_messages_for(:content)).to eq(['Content is too long (maximum is 140 characters)'])
+          expect(post.errors.full_messages_for(:content)).to eq(['Contentは140文字以内で入力してください'])
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe User, type: :model do
         aggregate_failures do
           user.valid?
           expect(user.errors.details[:email]).to include(error: :blank)
-          expect(user.errors.full_messages_for(:email)).to eq(["Email can't be blank"])
+          expect(user.errors.full_messages_for(:email)).to eq(['Emailを入力してください'])
         end
       end
     end
@@ -31,7 +31,7 @@ RSpec.describe User, type: :model do
         aggregate_failures do
           user.valid?
           expect(user.errors.details[:password]).to include(error: :blank)
-          expect(user.errors.full_messages_for(:password)).to eq(["Password can't be blank"])
+          expect(user.errors.full_messages_for(:password)).to eq(['Passwordを入力してください'])
         end
       end
     end


### PR DESCRIPTION
## 今回対応した issue

<!-- #の後に続けてissue番号を追記すること。 -->

- closes #19 

## やったこと

<!-- このプルリクで何をしたのか？ -->

- 投稿一覧画面にページネーションを追加した
  - pagy gemを導入した
- 日本語化した
  - fakerで日本語を使いたかったため

## 残りの作業

<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->

- なし

## できるようになること（ユーザ目線）

<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->

- 投稿を10件ずつ表示する

## できなくなること（ユーザ目線）

<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->

- 10件を超える投稿をまとめてみること

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->

- 外観の調整は今後やっていく

## 動作確認

<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

https://github.com/ok-os-job-change-team/tetsuya-twitter-clone-bootcamp/assets/95535099/db7c80f6-ddfb-4953-b61b-6715203d8c0c



