### PR TITLE
change: 投稿一覧のページネーションをカーソルページネーションに変更し、表示順序をID降順に変更した

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,7 +2,6 @@
 
 class Post < ApplicationRecord
   POSTS_PER_PAGE = 20
-  MAX_NUM_PAGES_DISPLAYED = 5
 
   belongs_to :user
   has_many :favorites, dependent: :destroy
@@ -16,67 +15,105 @@ class Post < ApplicationRecord
   before_validation :set_default_values
 
   class << self
-    def search_by_content_or_title(query, current_page)
-      offset = (current_page - 1) * POSTS_PER_PAGE
-
-      if query.blank?
-        search_all_posts(offset, current_page)
+    def resolve_posts_with_pagination(query: nil, last_post_id: nil, first_post_id: nil)
+      if query
+        resolve_posts_searched_with_query_and_cursors(query:, last_post_id:,
+                                                      first_post_id:)
       else
-        search_with_query(query, offset, current_page)
+        resolve_posts_and_cursors(last_post_id:, first_post_id:)
       end
     end
 
     private
 
-    def search_all_posts(offset, current_page)
-      limit = POSTS_PER_PAGE * calculate_num_pages_on_standby(current_page)
+    def resolve_cursors(posts:)
+      next_cursor = posts.last&.id
+      prev_cursor = posts.first&.id
 
-      # 現在ページから、最大表示ページ数に達する数の投稿を取得する
-      posts_on_standby = offset(offset).limit(limit).eager_load(:user)
-      posts_to_display = posts_on_standby[0...POSTS_PER_PAGE]
-
-      # 実際に得られた投稿数から、表示する残りページ数を計算する
-      upcoming_page_count = (posts_on_standby.size.to_f / POSTS_PER_PAGE).ceil
-
-      [posts_to_display, upcoming_page_count]
+      [next_cursor, prev_cursor]
     end
 
-    def search_with_query(query, offset, current_page)
-      limit = POSTS_PER_PAGE * calculate_num_pages_on_standby(current_page)
+    def resolve_posts_and_cursors(last_post_id: nil, first_post_id: nil)
+      posts = resolve_posts_with_no_query(last_post_id:, first_post_id:)
+      posts = order(id: :desc).limit(POSTS_PER_PAGE).eager_load(:user) if posts.empty?
 
-      # 最大表示ページ数に達する数の投稿を取得するためのSQLをセットする
-      sanitized_query = sanitize_sql_like(query)
-      posts_on_standby = \
-        find_by_sql([set_query_with_pagination(limit, offset), { query: "#{sanitized_query}%" }])
-      ActiveRecord::Associations::Preloader.new(records: posts_on_standby, associations: :user).call
-      posts_to_display = posts_on_standby[0...POSTS_PER_PAGE]
+      next_cursor, prev_cursor = resolve_cursors(posts:)
 
-      # 実際に得られた投稿数から、表示する残りページ数を計算する
-      upcoming_page_count = (posts_on_standby.size.to_f / POSTS_PER_PAGE).ceil
-
-      [posts_to_display, upcoming_page_count]
+      [posts, next_cursor, prev_cursor]
     end
 
-    # 現在ページから最大表示ページ数に達するために必要なページ数の計算
-    def calculate_num_pages_on_standby(current_page)
-      if current_page <= (MAX_NUM_PAGES_DISPLAYED + 1) / 2
-        MAX_NUM_PAGES_DISPLAYED - (current_page - 1)
+    def resolve_posts_searched_with_query(sanitized_query:, last_post_id: nil, first_post_id: nil)
+      if last_post_id
+        Post.find_by_sql(resolve_query_with_cursor(sanitized_query:, cursor: last_post_id,
+                                                   direction: :desc))
+      elsif first_post_id
+        posts = Post.find_by_sql(resolve_query_with_cursor(sanitized_query:, cursor: first_post_id,
+                                                           direction: :asc))
+        posts.reverse
       else
-        MAX_NUM_PAGES_DISPLAYED / 2 + 1
+        Post.find_by_sql(resolve_query(sanitized_query:))
       end
     end
 
-    def set_query_with_pagination(limit, offset)
-      <<-SQL
-        SELECT * FROM (
-          SELECT `posts`.* FROM `posts`
-          WHERE content LIKE :query
-          UNION ALL
-          SELECT `posts`.* FROM `posts`
-          WHERE title LIKE :query
-        ) AS combined_results
-        LIMIT #{limit} OFFSET #{offset}
-      SQL
+    def resolve_posts_searched_with_query_and_cursors(query: nil, last_post_id: nil, first_post_id: nil)
+      sanitized_query = sanitize_sql_like(query)
+      posts = resolve_posts_searched_with_query(sanitized_query:, last_post_id:, first_post_id:)
+
+      posts = Post.find_by_sql(resolve_query(sanitized_query:)) if posts.empty?
+
+      resolve_preloading_user(posts:)
+
+      next_cursor, prev_cursor = resolve_cursors(posts:)
+
+      [posts, next_cursor, prev_cursor]
+    end
+
+    def resolve_posts_with_no_query(last_post_id: nil, first_post_id: nil)
+      if last_post_id
+        where('posts.id < ?', last_post_id).order(id: :desc).limit(POSTS_PER_PAGE).eager_load(:user)
+      elsif first_post_id
+        posts = where('posts.id > ?', first_post_id).order(id: :asc).limit(POSTS_PER_PAGE).eager_load(:user)
+        posts.reverse
+      else
+        order(id: :desc).limit(POSTS_PER_PAGE).eager_load(:user)
+      end
+    end
+
+    def resolve_preloading_user(posts:)
+      ActiveRecord::Associations::Preloader.new(records: posts, associations: :user).call
+    end
+
+    def resolve_query(sanitized_query:)
+      Post.sanitize_sql_array([
+                                <<~SQL,
+                                  (SELECT * FROM posts WHERE content LIKE ?)
+                                  UNION ALL
+                                  (SELECT * FROM posts WHERE title LIKE ?)
+                                  ORDER BY id DESC
+                                  LIMIT #{POSTS_PER_PAGE}
+                                SQL
+                                "#{sanitized_query}%", "#{sanitized_query}%"
+                              ])
+    end
+
+    def resolve_query_with_cursor(sanitized_query:, cursor:, direction:)
+      order = direction == :asc ? 'ASC' : 'DESC'
+      comparator = direction == :asc ? '>' : '<'
+
+      resolve_query_with_order_and_comparator(sanitized_query:, cursor:, order:, comparator:)
+    end
+
+    def resolve_query_with_order_and_comparator(sanitized_query:, cursor:, order:, comparator:)
+      Post.sanitize_sql_array([
+                                <<~SQL,
+                                  (SELECT * FROM posts WHERE content LIKE ? AND posts.id #{comparator} ?)
+                                  UNION ALL
+                                  (SELECT * FROM posts WHERE title LIKE ? AND posts.id #{comparator} ?)
+                                  ORDER BY id #{order}
+                                  LIMIT #{POSTS_PER_PAGE}
+                                SQL
+                                "#{sanitized_query}%", cursor, "#{sanitized_query}%", cursor
+                              ])
     end
   end
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -34,25 +34,15 @@
     </div>
   <% end %>
 
-  <% if @upcoming_page_count > 1 || @current_page > 1 %>
-    <nav class="pagination" role="navigation" aria-label="pagination">
-      <ul class="pagination-list">
-        <% if @current_page > 1 %>
-          <li>
-            <%= link_to '<', posts_path(page: @current_page - 1, query: @query), class: 'pagination-previous' %>
-          </li>
-        <% end %>
-        <% @page_range.each do |page| %>
-          <li style="margin: 0;">
-            <%= link_to page, posts_path(page: page, query: @query), class: 'pagination-link' %>
-          </li>
-        <% end %>
-        <% if @upcoming_page_count > 1 %>
-          <li style="margin: 0;">
-            <%= link_to '>', posts_path(page: @current_page + 1, query: @query), class: 'pagination-next' %>
-          </li>
-        <% end %>
-      </ul>
-    </nav>
-  <% end %>
+  <nav class="pagination" role="navigation" aria-label="pagination">
+    <ul class="pagination-list">
+      <li style="margin: 0;">
+        <%= link_to '< prev', posts_path(first_post_id: @prev_cursor, query: params[:query]), class: 'pagination-previous' %>
+      </li>
+
+      <li style="margin: 0;">
+        <%= link_to 'next >', posts_path(last_post_id: @next_cursor, query: params[:query]), class: 'pagination-next' %>
+      </li>
+    </ul>
+  </nav>
 </div>

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -61,41 +61,41 @@ RSpec.describe PostsController, type: :request do
       end
     end
 
-    context '30件のポストについて' do
+    context '60件のポストについて' do
       let!(:posts) { create_list(:post, 60, user:) } # 60件の投稿を作成
 
       context 'ログイン状態でポスト一覧にアクセスするとき' do
         include_context 'userでログインする'
 
         context '1ページ目にアクセスするとき' do
-          it '1~20番目のポストが表示される' do
+          it '60~41番目のポストが表示される' do
             aggregate_failures do
-              get posts_path, params: { page: 1 }
+              get posts_path
               expect(response).to have_http_status(:success)
-              expect(response.body).to include posts[0].content
-              expect(response.body).to include posts[19].content
+              expect(response.body).to include posts[-1].content
+              expect(response.body).to include posts[- Post::POSTS_PER_PAGE].content
             end
           end
         end
 
         context '2ページ目にアクセスするとき' do
-          it '21~40番目のポストが表示される' do
+          it '40~21番目のポストが表示される' do
             aggregate_failures do
-              get posts_path, params: { page: 2 }
+              get posts_path, params: { last_post_id: posts[- Post::POSTS_PER_PAGE].id }
               expect(response).to have_http_status(:success)
-              expect(response.body).to include posts[20].content
-              expect(response.body).to include posts[39].content
+              expect(response.body).to include posts[-1 - Post::POSTS_PER_PAGE].content
+              expect(response.body).to include posts[- Post::POSTS_PER_PAGE * 2].content
             end
           end
         end
 
         context '3ページ目にアクセスするとき' do
-          it '41~60番目のポストが表示される' do
+          it '20~1番目のポストが表示される' do
             aggregate_failures do
-              get posts_path, params: { page: 3 }
+              get posts_path, params: { last_post_id: posts[- Post::POSTS_PER_PAGE * 2].id }
               expect(response).to have_http_status(:success)
-              expect(response.body).to include posts[40].content
-              expect(response.body).to include posts[59].content
+              expect(response.body).to include posts[-1 - Post::POSTS_PER_PAGE * 2].content
+              expect(response.body).to include posts[- Post::POSTS_PER_PAGE * 3].content
             end
           end
         end


### PR DESCRIPTION
## 今回対応した issue

<!-- #の後に続けてissue番号を追記すること。 -->

- closes #83 

## やったこと

<!-- このプルリクで何をしたのか？ -->

- 投稿一覧画面のページネーションをカーソルページネーションに変更した
- 投稿一覧画面の投稿表示順序を、ID降順に変更した

## 残りの作業

<!-- issueの残りの完了条件（あれば。無いなら「無し」で OK）（やらない場合は、いつやるのかを明記する。） -->

- なし

## できるようになること（ユーザ目線）

<!-- 何ができるようになるのか？（あれば。無いなら「無し」で OK） -->

- より高速なページネーション

## できなくなること（ユーザ目線）

<!-- 何ができなくなるのか？（あれば。無いなら「無し」で OK） -->

- ページ番号を指定したページ移動

## その他

<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->

- なし

## 動作確認

<!-- どのような動作確認を行ったのか？　結果はどうか？ -->

- 全投稿表示

https://github.com/user-attachments/assets/3cf04aff-ccaf-4457-b4b6-c4da38722257

- 検索結果表示

https://github.com/user-attachments/assets/da6b19cd-6ee0-4dff-904d-a0ded4d04020


